### PR TITLE
Adding requestConnectionPriority for Android API 21 and greater

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.ParcelUuid;
+import android.os.Build;
 import android.util.Base64;
 
 import android.app.Activity;

--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -1686,73 +1686,76 @@ public class BluetoothLePlugin extends CordovaPlugin
 
   private void requestConnectionPriorityAction(JSONArray args, CallbackContext callbackContext)
   {
-    if(isNotInitialized(callbackContext, true))
+    if (Build.VERSION.SDK_INT >= 21) 
     {
-      return;
+	if(isNotInitialized(callbackContext, true))
+	{
+		return;
+	}
+	
+	JSONObject obj = getArgsObject(args);
+	
+	if (isNotArgsObject(obj, callbackContext))
+	{
+		return;
+	}
+	
+	String address = getAddress(obj);
+	
+	if (isNotAddress(address, callbackContext))
+	{
+		return;
+	}
+	
+	HashMap<Object, Object> connection = wasNeverConnected(address, callbackContext); 
+	if (connection == null)
+	{
+		return;
+	}
+	
+	BluetoothGatt bluetoothGatt = (BluetoothGatt)connection.get(keyPeripheral);
+	
+	String priority = obj.optString(keyConnectionPriority, null);
+	
+	int androidPriority = BluetoothGatt.CONNECTION_PRIORITY_BALANCED;
+	
+	if (priority == null)
+	{
+		return;
+	}
+	
+	else if (priority.equals(propertyConnectionPriorityLow))
+	{
+		androidPriority = BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER;
+	}
+	
+	else if (priority.equals(propertyConnectionPriorityBalanced))
+	{
+		androidPriority = BluetoothGatt.CONNECTION_PRIORITY_BALANCED;
+	}
+	
+	else if (priority.equals(propertyConnectionPriorityHigh))
+	{
+		androidPriority = BluetoothGatt.CONNECTION_PRIORITY_HIGH;
+	}
+	
+	else
+	{
+		return;
+	}
+	
+	boolean result = bluetoothGatt.requestConnectionPriority(androidPriority);
+	
+	JSONObject returnObj = new JSONObject();
+	
+	BluetoothDevice device = bluetoothGatt.getDevice();
+	
+	addProperty(returnObj, keyConnectionPriorityRequested, result);
+	
+	addDevice(returnObj, device);
+	
+	callbackContext.success(returnObj);
     }
-    
-    JSONObject obj = getArgsObject(args);
-    
-    if (isNotArgsObject(obj, callbackContext))
-    {
-      return;
-    }
-    
-    String address = getAddress(obj);
-    
-    if (isNotAddress(address, callbackContext))
-    {
-      return;
-    }
-    
-    HashMap<Object, Object> connection = wasNeverConnected(address, callbackContext); 
-    if (connection == null)
-    {
-      return;
-    }
-    
-    BluetoothGatt bluetoothGatt = (BluetoothGatt)connection.get(keyPeripheral);
-    
-    String priority = obj.optString(keyConnectionPriority, null);
-    
-    int androidPriority = BluetoothGatt.CONNECTION_PRIORITY_BALANCED;
-    
-    if (priority == null)
-    {
-      return;
-    }
-    
-    else if (priority.equals(propertyConnectionPriorityLow))
-    {
-      androidPriority = BluetoothGatt.CONNECTION_PRIORITY_LOW_POWER;
-    }
-    
-    else if (priority.equals(propertyConnectionPriorityBalanced))
-    {
-      androidPriority = BluetoothGatt.CONNECTION_PRIORITY_BALANCED;
-    }
-    
-    else if (priority.equals(propertyConnectionPriorityHigh))
-    {
-      androidPriority = BluetoothGatt.CONNECTION_PRIORITY_HIGH;
-    }
-    
-    else
-    {
-      return;
-    }
-    
-    boolean result = bluetoothGatt.requestConnectionPriority(androidPriority);
-    
-    JSONObject returnObj = new JSONObject();
-    
-    BluetoothDevice device = bluetoothGatt.getDevice();
-    
-    addProperty(returnObj, keyConnectionPriorityRequested, result);
-    
-    addDevice(returnObj, device);
-    
-    callbackContext.success(returnObj);
   }
   
   @Override

--- a/www/bluetoothle.js
+++ b/www/bluetoothle.js
@@ -78,6 +78,9 @@ var bluetoothle = {
   isDiscovered: function(successCallback, params) {
     cordova.exec(successCallback, successCallback, bluetoothleName, "isDiscovered", [params]);
   },
+  requestConnectionPriority: function(successCallback, errorCallback, params) {
+    cordova.exec(successCallback, errorCallback, bluetoothleName, "requestConnectionPriority", [params]); 
+  },
   encodedStringToBytes: function(string) {
     var data = atob(string);
     var bytes = new Uint8Array(data.length);


### PR DESCRIPTION
This series of commits give the BluetoothLE plugin the ability to request a connection priority with the latest version of the Android API. If you set your target system to build and API version 19 or 20 the new code will not do anything if called. This new code does require a users manual change their project.properties file and then set "target=android-21" instead of "target=android-19".

Have done extensive benchmarking on this new patch but I have confirmed that the Android device does request to the BLE device that it is connected with to change it's hopping interval speed and therefor increase the theoretical bandwidth.