### PR TITLE
Require bluetooth LE on AndroidManifest.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.BLUETOOTH"/>
       <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+      <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     </config-file>
   </platform>
   <platform name="ios">


### PR DESCRIPTION
Require 'android.hardware.bluetooth_le' feature on Android device in config.xml, in order to insert de matching ``<uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />`` on AndroidManifest.xml